### PR TITLE
feat: migrate from deprecated Reporting API to Query API

### DIFF
--- a/tap_rokt/client.py
+++ b/tap_rokt/client.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 
 class RoktClient:
     """
-    OAuth2 client_credentials for Rokt Reporting API
+    OAuth2 client_credentials for Rokt Query API
     """
 
     def __init__(self, client_id: str, client_secret: str, token_url: str, api_base: str):
@@ -52,9 +52,7 @@ class RoktClient:
         
         url = f"{self.api_base}{path}"
         self.logger.info(f"Making POST request to: {url}")
-        self.logger.debug(f"Headers: {headers}")
-        
+
         resp = self.session.post(url, headers=headers, json=body)
-        self.logger.info(f"Response: {resp.json()}")
         resp.raise_for_status()
         return resp.json()

--- a/tap_rokt/streams.py
+++ b/tap_rokt/streams.py
@@ -27,6 +27,7 @@ class CampaignsBreakdownStream(Stream):
     schema = th.PropertiesList(
         th.Property("campaign_id", th.StringType),
         th.Property("campaign_name", th.StringType),
+        th.Property("datetime", th.StringType),
         th.Property("date", th.StringType),
         th.Property("impressions", th.NumberType),
         th.Property("referrals", th.NumberType),
@@ -68,9 +69,9 @@ class CampaignsBreakdownStream(Stream):
         self.account_id = cfg["account_id"]
 
         now = datetime.utcnow()
-        default_end = now.strftime("%Y-%m-%d") + "T23:59:59.000"
-        default_start = (now - timedelta(days=cfg.get("days_back", 14))).strftime("%Y-%m-%d")
-        default_start = default_start + "T00:00:00.000"
+        days_back = cfg.get("days_back", 14)
+        default_start = (now - timedelta(days=days_back)).strftime("%Y-%m-%d")
+        default_end = (now + timedelta(days=1)).strftime("%Y-%m-%d")
 
         self.start_date = cfg.get("start_date") or default_start
         self.end_date = cfg.get("end_date") or default_end
@@ -82,53 +83,55 @@ class CampaignsBreakdownStream(Stream):
         return response if isinstance(response, list) else []
 
     def get_records(self, context: dict | None) -> t.Iterable[dict]:
-        """Fetch campaign breakdown data one day at a time, inclusive."""
+        """Fetch campaign breakdown data from the Query API."""
         path = self.path.format(account_id=self.account_id)
-        start_date_obj = self.start_date
-        end_date_obj = self.end_date
 
         body = {
-                "interval": "day",
-                "startDate": start_date_obj,
-                "endDate": end_date_obj,
-                "dimensionFilters": {},
-                "metrics": [
-                    "impressions",
-                    "referrals",
-                    "gross_cost",
-                    "net_cost",
-                    "click_thru_acquisitions",
-                    "click_thru_acquisitions_by_conversion_time",
-                    "view_thru_acquisitions_by_conversion_time",
-                    "acquisitions_by_conversion_time",
-                    "click_thru_conversions",
-                    "click_thru_conversions_by_conversion_time",
-                    "view_thru_conversions_by_conversion_time",
-                    "view_thru_acquisitions",
-                    "view_thru_conversions",
-                    "acquisitions",
-                    "conversions",
-                    "conversions_by_conversion_time",
-                    "unique_creatives",
-                    "unique_campaigns",
-                    "unique_audiences",
-                    "unique_campaign_countries",
-                    "click_thru_conversion_value",
-                    "acquisitions_value",
-                    "conversion_value",
-                    "view_thru_acquisitions_value",
-                    "view_thru_conversion_value",
-                    "click_thru_acquisition_value"
-                ],
-                "dimensions": ["campaign_id", "campaign_name"],
-                "orderBys": [
-                    {
+            "timezoneVariation": self.time_zone_variation,
+            "currencyCode": self.currency,
+            "interval": "day",
+            "startDate": self.start_date,
+            "endDate": self.end_date,
+            "dimensionFilters": {},
+            "metrics": [
+                "impressions",
+                "referrals",
+                "gross_cost",
+                "net_cost",
+                "click_thru_acquisitions",
+                "click_thru_acquisitions_by_conversion_time",
+                "view_thru_acquisitions_by_conversion_time",
+                "acquisitions_by_conversion_time",
+                "click_thru_conversions",
+                "click_thru_conversions_by_conversion_time",
+                "view_thru_conversions_by_conversion_time",
+                "view_thru_acquisitions",
+                "view_thru_conversions",
+                "acquisitions",
+                "conversions",
+                "conversions_by_conversion_time",
+                "unique_creatives",
+                "unique_campaigns",
+                "unique_audiences",
+                "unique_campaign_countries",
+                "click_thru_conversion_value",
+                "acquisitions_value",
+                "conversion_value",
+                "view_thru_acquisitions_value",
+                "view_thru_conversion_value",
+                "click_thru_acquisition_value",
+            ],
+            "dimensions": ["campaign_id", "campaign_name"],
+            "orderBys": [
+                {
                     "column": "referrals",
-                    "direction": "desc"
-                    }
-                ]
+                    "direction": "desc",
+                }
+            ],
         }
-        self.logger.info(f"Fetching data for {start_date_obj} to {end_date_obj}")
+        self.logger.info(
+            f"Fetching data for {self.start_date} to {self.end_date}"
+        )
         response = self.client.post(path, body=body)
         records = response["data"]
         for record in records:

--- a/tap_rokt/tap.py
+++ b/tap_rokt/tap.py
@@ -19,7 +19,7 @@ class TapRokt(Tap):
             "client_id",
             th.StringType(nullable=False),
             required=True,
-            secret=True,  # Flag config as protected.
+            secret=True,
             title="Client ID",
             description="The client ID to authenticate against the API service",
         ),
@@ -27,7 +27,7 @@ class TapRokt(Tap):
             "client_secret",
             th.StringType(nullable=False),
             required=True,
-            secret=True,  # Flag config as protected.
+            secret=True,
             title="Client Secret",
             description="The client secret to authenticate against the API service",
         ),
@@ -35,18 +35,38 @@ class TapRokt(Tap):
             "account_id",
             th.StringType(nullable=False),
             required=True,
-            secret=True,  # Flag config as protected.
+            secret=True,
             title="Account ID",
             description="The account ID to sync",
         ),
         th.Property(
             "start_date",
             th.DateTimeType(nullable=True),
-            description="The earliest record date to sync",
+            description="The earliest record date to sync (YYYY-MM-DD)",
+        ),
+        th.Property(
+            "end_date",
+            th.DateTimeType(nullable=True),
+            description="The exclusive end date for syncing (YYYY-MM-DD)",
+        ),
+        th.Property(
+            "days_back",
+            th.IntegerType(nullable=True),
+            description="Number of days back from today to sync (default: 14)",
+        ),
+        th.Property(
+            "currency",
+            th.StringType(nullable=True),
+            description="Currency code for monetary metrics (default: USD)",
+        ),
+        th.Property(
+            "time_zone_variation",
+            th.StringType(nullable=True),
+            description="Timezone in Olson format (default: UTC)",
         ),
     ).to_dict()
 
-    def discover_streams(self) -> list[streams.RoktStream]:
+    def discover_streams(self) -> list[streams.CampaignsBreakdownStream]:
         """Return a list of discovered streams.
 
         Returns:


### PR DESCRIPTION
- Update CampaignsBreakdownStream to POST to /v1/query/accounts/{id}/campaigns/
- Fix endDate to use exclusive YYYY-MM-DD format (was T23:59:59.000)
- Fix startDate to use YYYY-MM-DD format (was T00:00:00.000)
- Add currencyCode and timezoneVariation to request body
- Add datetime field to schema
- Expose end_date, days_back, currency, time_zone_variation as tap config props
- Fix discover_streams return type hint (RoktStream -> CampaignsBreakdownStream)
- Remove debug header logging to prevent bearer token exposure